### PR TITLE
don't send nil parameters to cloudflare

### DIFF
--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -535,7 +535,7 @@ module CloudFlare
       end
 
       req = Net::HTTP::Post.new(uri.path)
-      req.set_form_data(params)
+      req.set_form_data(params.reject{|k, v| v.nil?})
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -19,5 +19,5 @@
 # THE SOFTWARE.
 
 module CloudFlare
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end


### PR DESCRIPTION
Recently some of my CloudFlare API requests started getting rejected. I traced it to the fact that this library sends parameters with nil arguments, and for many of the commands the library's implementation causes all unset parameters are passed with no argument.

This pull request prevents nil parameters from being passed on to CloudFlare. I've checked the CloudFlare [API docs](https://www.cloudflare.com/docs/client-api.html), and there is no defined behavior for setting any parameter without a value anyway, so this change shouldn't cause a problem.