### PR TITLE
Remove explicit dependency on stdlib gems

### DIFF
--- a/cloudflare.gemspec
+++ b/cloudflare.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md', 'LICENSE']
 
   s.required_ruby_version = '>= 1.9.0'
-  s.add_runtime_dependency 'json', '~> 1'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
`json` is included in the Ruby Standard Library for all versions of Ruby supported by this gem (1.9+).